### PR TITLE
chore(k8s-version): adapt current k8s-versions to our repo

### DIFF
--- a/01_core_cluster/.terraform.lock.hcl
+++ b/01_core_cluster/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "~> 3.47.0"
   hashes = [
     "h1:4E4RMborg5NB/V0tJ/AQUhyuG4f4reQURDahUZTPm5o=",
+    "h1:gWdjrOUCdfRB5VrQ0qxJI/coNh5chWw9884qM/nTg0E=",
     "zh:099ffaec3ef0ef45a23aebd851fdf49a279f872632dd2e72fa3cb897621511ac",
     "zh:0a2c33eff74c8934a371cff9647edc59a35cd2810d63613e5de4f6f2e43ae014",
     "zh:0ac4934c8ebff2cdb5aba2728693ba8e2143f7a16f51dadaff5847a442d535b3",

--- a/01_core_cluster/main.tf
+++ b/01_core_cluster/main.tf
@@ -2,6 +2,7 @@ module "core_cluster" {
   source = "../modules/consortium_cluster"
 
   cluster_name = "core"
+  k8s_cluster_node_count = 4
 
   provider_azure_dns_subscription_id       = var.provider_azure_dns_subscription_id
   provider_azure_subscription_id           = var.provider_azure_subscription_id

--- a/02_devsecops_testing_cluster/.terraform.lock.hcl
+++ b/02_devsecops_testing_cluster/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "~> 3.47.0"
   hashes = [
     "h1:4E4RMborg5NB/V0tJ/AQUhyuG4f4reQURDahUZTPm5o=",
+    "h1:gWdjrOUCdfRB5VrQ0qxJI/coNh5chWw9884qM/nTg0E=",
     "zh:099ffaec3ef0ef45a23aebd851fdf49a279f872632dd2e72fa3cb897621511ac",
     "zh:0a2c33eff74c8934a371cff9647edc59a35cd2810d63613e5de4f6f2e43ae014",
     "zh:0ac4934c8ebff2cdb5aba2728693ba8e2143f7a16f51dadaff5847a442d535b3",

--- a/06_beta_cluster/.terraform.lock.hcl
+++ b/06_beta_cluster/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "~> 3.47.0"
   hashes = [
     "h1:4E4RMborg5NB/V0tJ/AQUhyuG4f4reQURDahUZTPm5o=",
+    "h1:gWdjrOUCdfRB5VrQ0qxJI/coNh5chWw9884qM/nTg0E=",
     "zh:099ffaec3ef0ef45a23aebd851fdf49a279f872632dd2e72fa3cb897621511ac",
     "zh:0a2c33eff74c8934a371cff9647edc59a35cd2810d63613e5de4f6f2e43ae014",
     "zh:0ac4934c8ebff2cdb5aba2728693ba8e2143f7a16f51dadaff5847a442d535b3",

--- a/06_beta_cluster/main.tf
+++ b/06_beta_cluster/main.tf
@@ -4,7 +4,7 @@ module "beta_cluster" {
   cluster_name = "beta"
 
   public_ip_ddos_protection_mode = "VirtualNetworkInherited"
-  k8s_version = "1.23.12"
+  k8s_cluster_node_count = 4
 
   provider_azure_dns_subscription_id       = var.provider_azure_dns_subscription_id
   provider_azure_subscription_id           = var.provider_azure_subscription_id

--- a/08_stable_cluster/main.tf
+++ b/08_stable_cluster/main.tf
@@ -5,7 +5,6 @@ module "stable_cluster" {
 
   k8s_cluster_node_count = 4
   public_ip_ddos_protection_mode = "VirtualNetworkInherited"
-  k8s_version = "1.25.6"
 
   provider_azure_dns_subscription_id       = var.provider_azure_dns_subscription_id
   provider_azure_subscription_id           = var.provider_azure_subscription_id

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the [official installation instructions](https://learn.microsoft.com/en-us/cli/a
 Terraforming the environments almost always is done by issuing the following commands on your local machine:
 
 ```shell
-# Login with Azrue CLI
+# Login with Azure CLI
 az login --tenant <catena-x-azure-tenant-id>
 # Get credentials for Azure Storage account containing the terraform state files
 export ARM_ACCESS_KEY=$(az storage account keys list --resource-group cx-devsecops-tfstates --account-name cxdevsecopstfstate --query '[0].value' -o tsv)

--- a/modules/consortium_cluster/variables.tf
+++ b/modules/consortium_cluster/variables.tf
@@ -48,7 +48,7 @@ variable "k8s_cluster_node_count" {
 variable "k8s_version" {
   description = "AKS k8s Version to deploy"
   type        = string
-  default     = "1.24.6"
+  default     = "1.25.6"
 }
 
 variable "enable_auto_scaling" {


### PR DESCRIPTION
### Description of this Pull Request
#### What would be changed or will be added with this PR?
- adapt k8s_cluster_version to current kubernetes version as done over the web-ui from azure.
  - core-cluster
  - devsecopstesting
  - beta-cluster
  - stable
  - changed current version to all-cluster as default version to  `1.25.6`
- fixed typo `Azure` in ReadMe.md
#### Why do i want to change this?
- have the same state for all cluster (except INT-Hotel-Budapest)
#### Testing
- checkout branch
- switch to the cluster folder `0X_clustername` 
- `terraform init` (optional)
- Run `terraform plan` to get the information want terraform would change.
#### Additional information
``` markdown
### my results from my terraform plans against following clusters
01_core
No changes. Your infrastructure matches the configuration.
02_devsecopstesting
No changes. Your infrastructure matches the configuration.
03_dev
No changes. Your infrastructure matches the configuration.
06_beta
No changes. Your infrastructure matches the configuration.
08_stable
No changes. Your infrastructure matches the configuration.
```
![image](https://github.com/catenax-ng/cloud-infra/assets/121097161/25592aba-f9bc-4710-998d-1b83405bca0c)



[FaGru3n](https://github.com/FaGru3n), Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) </sub>