### PR TITLE
Chore/update k8s version

### DIFF
--- a/03_dev_cluster/main.tf
+++ b/03_dev_cluster/main.tf
@@ -4,7 +4,7 @@ module "dev_cluster" {
   cluster_name = "dev"
 
   default_node_pool_name = "defaultng"
-  k8s_cluster_node_count = 10
+  k8s_cluster_node_count = 13
 
   provider_azure_dns_subscription_id       = var.provider_azure_dns_subscription_id
   provider_azure_subscription_id           = var.provider_azure_subscription_id

--- a/04_int_cluster/README.md
+++ b/04_int_cluster/README.md
@@ -4,6 +4,6 @@
 > `modules/consortium` directory.
 
 Please keep in mind, that this cluster does not use the Terraform `modules/consortium` module, as INT cluster has been
-created manually when no standards were defined yet, which are enforced in the module and we decided to
-keep the module unchanged. Instead we created this Terraform script, based on the modules, including all required
+created manually when no standards were defined yet, which are enforced in the modules, and we decided to
+keep the module unchanged. Instead, we created this Terraform script, based on the modules, including all required
 changes to match deployed INT AKS cluster.

--- a/04_int_cluster/variables.tf
+++ b/04_int_cluster/variables.tf
@@ -43,13 +43,13 @@ variable "k8s_vm_size" {
 variable "k8s_cluster_node_count" {
   description = "The number of kubernetes nodes to create for the k8s cluster"
   type        = number
-  default     = 5
+  default     = 7
 }
 
 variable "k8s_version" {
   description = "AKS k8s Version to deploy"
   type        = string
-  default     = "1.25.6"
+  default     = "1.26.6"
 }
 
 variable "enable_auto_scaling" {
@@ -61,7 +61,7 @@ variable "enable_auto_scaling" {
 variable "max_count" {
   description = "If auto scaling is enabled the maximum number of nodes in the pool"
   type        = number
-  default     = 6
+  default     = 7
 }
 
 variable "min_count" {

--- a/modules/consortium_cluster/variables.tf
+++ b/modules/consortium_cluster/variables.tf
@@ -48,7 +48,7 @@ variable "k8s_cluster_node_count" {
 variable "k8s_version" {
   description = "AKS k8s Version to deploy"
   type        = string
-  default     = "1.25.6"
+  default     = "1.26.6"
 }
 
 variable "enable_auto_scaling" {


### PR DESCRIPTION
- adapt new cluster versions to our infrastructure (except stable environmnet was not manually updated)
- adapt current scaled nodes into our repository

reason https://github.com/eclipse-tractusx/sig-infra/issues/268

verified information via terraform plan which changed would be made after the manual update via Azure Web UI.

-  cx-devsecops-testing-aks
-  cx-dev-aks
-  cx-beta-aks
-  cx-core-aks
> No changes. Your infrastructure matches the configuration.
>
>Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

-  cxtsi-hotel-budapest-aks-services
Terraform test was validated with an plan an current repos settings are aligned with our config

