### PR TITLE
chore/update k8s 1.27.3

### DIFF
--- a/01_core_cluster/.terraform.lock.hcl
+++ b/01_core_cluster/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.61.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:3qOZEe76cSc1CjSn86j3ItrJk/4xv2UL/g8KkOUaWYo=",
     "h1:ygpAv2ggEm3aMJTPvlvVaPdegoxriKpDSXSbIO9qqB4=",
     "zh:1441e4e9b63801bc2432b1c06e0d202e66946c57abbf553d7f88fba5986e8f59",
     "zh:291f0db2808724119a079f9a30254dbeae4a450dbacdd8bbb821d9332b842b25",

--- a/02_devsecops_testing_cluster/.terraform.lock.hcl
+++ b/02_devsecops_testing_cluster/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.61.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:3qOZEe76cSc1CjSn86j3ItrJk/4xv2UL/g8KkOUaWYo=",
     "h1:ygpAv2ggEm3aMJTPvlvVaPdegoxriKpDSXSbIO9qqB4=",
     "zh:1441e4e9b63801bc2432b1c06e0d202e66946c57abbf553d7f88fba5986e8f59",
     "zh:291f0db2808724119a079f9a30254dbeae4a450dbacdd8bbb821d9332b842b25",

--- a/03_dev_cluster/.terraform.lock.hcl
+++ b/03_dev_cluster/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.61.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:3qOZEe76cSc1CjSn86j3ItrJk/4xv2UL/g8KkOUaWYo=",
     "h1:ygpAv2ggEm3aMJTPvlvVaPdegoxriKpDSXSbIO9qqB4=",
     "zh:1441e4e9b63801bc2432b1c06e0d202e66946c57abbf553d7f88fba5986e8f59",
     "zh:291f0db2808724119a079f9a30254dbeae4a450dbacdd8bbb821d9332b842b25",

--- a/04_int_cluster/.terraform.lock.hcl
+++ b/04_int_cluster/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.61.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:3qOZEe76cSc1CjSn86j3ItrJk/4xv2UL/g8KkOUaWYo=",
     "h1:ygpAv2ggEm3aMJTPvlvVaPdegoxriKpDSXSbIO9qqB4=",
     "zh:1441e4e9b63801bc2432b1c06e0d202e66946c57abbf553d7f88fba5986e8f59",
     "zh:291f0db2808724119a079f9a30254dbeae4a450dbacdd8bbb821d9332b842b25",

--- a/04_int_cluster/variables.tf
+++ b/04_int_cluster/variables.tf
@@ -43,13 +43,13 @@ variable "k8s_vm_size" {
 variable "k8s_cluster_node_count" {
   description = "The number of kubernetes nodes to create for the k8s cluster"
   type        = number
-  default     = 7
+  default     = 6
 }
 
 variable "k8s_version" {
   description = "AKS k8s Version to deploy"
   type        = string
-  default     = "1.26.6"
+  default     = "1.27.3"
 }
 
 variable "enable_auto_scaling" {

--- a/08_stable_cluster/.terraform.lock.hcl
+++ b/08_stable_cluster/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.61.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:3qOZEe76cSc1CjSn86j3ItrJk/4xv2UL/g8KkOUaWYo=",
     "h1:ygpAv2ggEm3aMJTPvlvVaPdegoxriKpDSXSbIO9qqB4=",
     "zh:1441e4e9b63801bc2432b1c06e0d202e66946c57abbf553d7f88fba5986e8f59",
     "zh:291f0db2808724119a079f9a30254dbeae4a450dbacdd8bbb821d9332b842b25",

--- a/08_stable_cluster/main.tf
+++ b/08_stable_cluster/main.tf
@@ -2,7 +2,7 @@ module "stable_cluster" {
   source = "../modules/consortium_cluster"
 
   cluster_name = "stable"
-
+  k8s_version = "1.25.6"
   k8s_cluster_node_count = 4
   public_ip_ddos_protection_mode = "VirtualNetworkInherited"
 

--- a/modules/consortium_cluster/variables.tf
+++ b/modules/consortium_cluster/variables.tf
@@ -48,7 +48,7 @@ variable "k8s_cluster_node_count" {
 variable "k8s_version" {
   description = "AKS k8s Version to deploy"
   type        = string
-  default     = "1.26.6"
+  default     = "1.27.3"
 }
 
 variable "enable_auto_scaling" {


### PR DESCRIPTION
- add new version information to consortium cluster
- settle the current version for stable cluster fix to 1.25.6
- reduced min node-pool on int to 6 because was current node size and autoscaling is enabled
- updated hcl terraform info