### PR TITLE
chore: 1. update bump k8s-version stable to 1.26.6

### DIFF
--- a/08_stable_cluster/main.tf
+++ b/08_stable_cluster/main.tf
@@ -2,7 +2,7 @@ module "stable_cluster" {
   source = "../modules/consortium_cluster"
 
   cluster_name = "stable"
-  k8s_version = "1.25.6"
+  k8s_version = "1.26.6"
   k8s_cluster_node_count = 4
   public_ip_ddos_protection_mode = "VirtualNetworkInherited"
 


### PR DESCRIPTION
- version bump to next version 1.26.6
- updates https://github.com/eclipse-tractusx/sig-infra/issues/352
#### Testing
- checkout branch 
- terraform init (optional)
- terraform plan
- validate changes

#### Additional information Terraform output

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.stable_cluster.azurerm_kubernetes_cluster.aks_cluster will be updated in-place
  ~ resource "azurerm_kubernetes_cluster" "aks_cluster" {
        id                                  = "/subscriptions/899135fc-19c6-47cb-82f1-0230af7b99b5/resourceGroups/cx-stable-rg/providers/Microsoft.ContainerService/managedClusters/cx-stable-aks"
      ~ kubernetes_version                  = "1.25.6" -> "1.26.6"
        name                                = "cx-stable-aks"
        tags                                = {}
        # (23 unchanged attributes hidden)

      ~ default_node_pool {
            name                         = "default"
          ~ orchestrator_version         = "1.25.6" -> "1.26.6"
            tags                         = {}
            # (21 unchanged attributes hidden)
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```
