### PR TITLE
chore: adapt node count and max_count to cluster settings

### DIFF
--- a/04_int_cluster/variables.tf
+++ b/04_int_cluster/variables.tf
@@ -43,7 +43,7 @@ variable "k8s_vm_size" {
 variable "k8s_cluster_node_count" {
   description = "The number of kubernetes nodes to create for the k8s cluster"
   type        = number
-  default     = 6
+  default     = 7
 }
 
 variable "k8s_version" {
@@ -61,7 +61,7 @@ variable "enable_auto_scaling" {
 variable "max_count" {
   description = "If auto scaling is enabled the maximum number of nodes in the pool"
   type        = number
-  default     = 7
+  default     = 8
 }
 
 variable "min_count" {


### PR DESCRIPTION
#### What would be changed or will be added with this PR?

- increase the number of nodes and max_count to current settings on the cluster

#### Why do i want to change this?
- reason https://github.com/eclipse-tractusx/sig-infra/issues/423 we identified that cluster capacity is on limit

#### Testing

- validation 

![image](https://github.com/catenax-ng/cloud-infra/assets/121097161/7014a62b-664a-46d0-8e3f-e48486a3c9d1)

- run `terraform plan`
- output

```bash
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

```
